### PR TITLE
Feature/fix ec2 instance support

### DIFF
--- a/inc/aws_ops.class.php
+++ b/inc/aws_ops.class.php
@@ -23,8 +23,8 @@ class tcs3_aws_ops
 
         if (!empty($this->options['access_key']) && !empty($this->options['access_secret'])) {
             $config['credentials'] = [
-                'key' => $this->options["access_key"],
-                        'secret' => $this->options["access_secret"]
+                'key' => $this->options['access_key'],
+                'secret' => $this->options['access_secret']
             ];
         }
 
@@ -36,14 +36,14 @@ class tcs3_aws_ops
         $success = true;
 
         $uploader = new MultipartUploader($this->s3, $localFile, [
-            'bucket' => $this->options["bucket"],
+            'bucket' => $this->options['bucket'],
             'key'    => $this->s3->encodeKey($remoteFile),
-            'concurrency' => $this->options["concurrent_conn"],
-            'part_size' => $this->options["min_part_size"] * 1024 * 1024,
+            'concurrency' => $this->options['concurrent_conn'],
+            'part_size' => $this->options['min_part_size'] * 1024 * 1024,
             'acl' => 'public-read',
             'before_initiate' => function (\Aws\Command $command) {
                 // $command is a CreateMultipartUpload operation
-                $command['CacheControl'] = 'max-age=' . $this->options["s3_cache_time"];
+                $command['CacheControl'] = 'max-age=' . $this->options['s3_cache_time'];
             }
         ]);
 
@@ -59,9 +59,9 @@ class tcs3_aws_ops
 
     public function s3_delete($file)
     {
-        if ($this->s3->doesObjectExist($this->options["bucket"], $file)) {
+        if ($this->s3->doesObjectExist($this->options['bucket'], $file)) {
             $result = $this->s3->deleteObject([
-                'Bucket' => $this->options["bucket"],
+                'Bucket' => $this->options['bucket'],
                 'Key' => $file
             ]);
         } else {
@@ -73,11 +73,11 @@ class tcs3_aws_ops
 
     public function build_attachment_key($path)
     {
-        $key = str_replace($this->options["local_path"], "", $path);
+        $key = str_replace($this->options['local_path'], '', $path);
 
-        $key = $this->options["bucket_path"] . "/" . $key;
+        $key = $this->options['bucket_path'] . '/' . $key;
 
-        $key = preg_replace(["/[\/]+/", "/^\//"], ["/", ""], trim($key));
+        $key = preg_replace(["/[\/]+/", "/^\//"], ['/', ''], trim($key));
 
         return $key;
     }

--- a/inc/aws_ops.class.php
+++ b/inc/aws_ops.class.php
@@ -16,19 +16,25 @@ class tcs3_aws_ops
 
     public function build_aws_config()
     {
-        return [
-            'region' => $this->options["bucket_region"],
-            "version" => "2006-03-01",
-            "credentials" => [
-                'key' => $this->options["access_key"],
-                'secret' => $this->options["access_secret"]
-            ]
+        $config = [
+            'region' => $this->options['bucket_region'],
+            'version' => '2006-03-01'
         ];
+
+        if (!empty($this->options['access_key']) && !empty($this->options['access_secret'])) {
+            $config['credentials'] = [
+                'key' => $this->options["access_key"],
+                        'secret' => $this->options["access_secret"]
+            ];
+        }
+
+        return $config;
     }
 
     public function s3_upload($localFile, $remoteFile)
     {
         $success = true;
+
         $uploader = new MultipartUploader($this->s3, $localFile, [
             'bucket' => $this->options["bucket"],
             'key'    => $this->s3->encodeKey($remoteFile),


### PR DESCRIPTION
The plugin wasn't originally picking up the EC2 instance configuration. By only supplying credentials when needed the `S3Client` will use `CredentialProvider::defaultProvider` "that first checks for environment variables, then checks for the "default" profile in ~/.aws/credentials, then checks for "profile default" profile in ~/.aws/config (which is the default profile of AWS CLI), then tries to make a GET Request to fetch credentials if Ecs environment variable is presented, and finally checks for EC2 instance profile credentials."