### PR TITLE
Feature/sync all files individually

### DIFF
--- a/inc/aws_ops.class.php
+++ b/inc/aws_ops.class.php
@@ -29,6 +29,12 @@ class tcs3_aws_ops
     public function s3_upload($localFile, $remoteFile)
     {
         $success = true;
+
+        if (!file_exists($localFile)) {
+            error_log(sprintf("%s doesn't exist", $localFile));
+            return false;
+        }
+
         $uploader = new MultipartUploader($this->s3, $localFile, [
             'bucket' => $this->options["bucket"],
             'key'    => $this->s3->encodeKey($remoteFile),

--- a/inc/titan-framework/lib/class-option-ajax-button.php
+++ b/inc/titan-framework/lib/class-option-ajax-button.php
@@ -211,13 +211,13 @@ class TitanFrameworkOptionAjaxButton extends TitanFrameworkOption {
 						}
 						$(this).text( successMessage );
 
-						// Call the error callback
+						this.doingAjax = false;
+						// Call the success callback
 						if ( $(this).attr('data-success-callback') != '' ) {
 							if ( typeof window[ $(this).attr('data-success-callback') ] != 'undefined' ) {
 								window[ $(this).attr('data-success-callback') ]( data );
 							}
 						}
-						this.doingAjax = false;
 
 					}.bind(this),
 

--- a/inc/wp_options.class.php
+++ b/inc/wp_options.class.php
@@ -244,7 +244,9 @@ class tcs3_wp_options
                   'desc' => "This will push all of your existing uploads to S3. This process can be resource intensive so if you have a lot of uploads we recommend you upload them a different way",
                   "action" => "sync_all",
                   "label" => "Sync",
-                  "class" => "button-primary"
+                  "class" => "button-primary",
+                  "success_callback" => "sync_all_callback",
+                  "data_filter_callback" => "sync_all_filter"
                 ]
 
               ] //end s3 sync fields
@@ -262,3 +264,24 @@ class tcs3_wp_options
         update_site_option("tcS3_options", $network_options);
     }
 }
+
+
+add_action('admin_footer', function() {
+    ?>
+    <script>
+        function sync_all_callback(data) {
+		window.nextAttachment = null;
+		if (typeof(data.next) !== 'undefined') {
+			window.nextAttachment = data.next;
+			jQuery('button[data-action="sync_all"]').first().click();
+		}
+        }
+	function sync_all_filter(data) {
+		if (typeof(window.nextAttachment) !== 'undefined' && window.nextAttachment !== null) {
+			data.next = window.nextAttachment;
+		}
+		return data;
+	}
+    </script>
+    <?php
+});


### PR DESCRIPTION
Instead of bulk uploading all attachments at the same time this will upload each file individually in its very own call.

Possible todo:
* Save list of ids returning errors and display to the user.
* Show progress counter `current/total`