### PR TITLE
Fix WP Cli error and network_options notice

### DIFF
--- a/inc/base.class.php
+++ b/inc/base.class.php
@@ -48,7 +48,7 @@ class tcs3_base
             $network_options = $this->unserialize(get_site_option("tcS3_options"));
         }
 
-        if (is_array($network_options)) {
+        if (!empty($network_options)) {
             $options = array_merge($options, $network_options);
         }
 

--- a/tcS3.php
+++ b/tcS3.php
@@ -16,7 +16,9 @@
  {
      public function __construct()
      {
-         add_action("after_setup_theme", [$this, "init"], 20);
+         if (php_sapi_name() !== "cli") {
+            add_action("after_setup_theme", [$this, "init"], 20);
+         }
          add_action("admin_enqueue_scripts", [$this, "scripts"], 20);
      }
 


### PR DESCRIPTION
This fixes an issue where WP-CLI would crash and a notice caused by `network_options` not being set.